### PR TITLE
[fix][vuln] Need-to-know disclosure of personal info to admins

### DIFF
--- a/imports/model/user.ts
+++ b/imports/model/user.ts
@@ -136,14 +136,17 @@ if (Meteor.isServer) {
             const isAdmin = user.isAdmin
 
             debug(`Disclosing %s to ${userId}`,
-                  isAdmin ? "everyone's names" : "his/her own name")
+                  isAdmin ? "all users' personal data" : "their own personal data")
             return new MapCursor(
                 Meteor.users.find(isAdmin ? {} : {_id: userId}),
                 (changes: any, id: string) => {
                     if (id === userId) {
                         changes.isAdmin = isAdmin
+                        return changes
+                    } else {
+                        const disclosed = _.pick(changes, ['_id', 'tequila'])
+                        return disclosed
                     }
-                    return changes
                 },
                 MeteorUsersCollectionName)
         })


### PR DESCRIPTION
As the `Meteor.publish("users", ...)` logic was previously written, admins would receive the *entire* contents of the `users` server-side database, including security tokens that allow administrators to impersonate other users...

- Refactor to clearly distinguish processing one's own identity vs. other people's identities (admin-only code path)
- In the latter, be sure to use a whitelist-based disclosure (fashioned with `_.pick`)