### PR TITLE
[bump] memory requirements

### DIFF
--- a/ansible/roles/epfl.phd-assess/tasks/_zeebe-k8s-broker.yml
+++ b/ansible/roles/epfl.phd-assess/tasks/_zeebe-k8s-broker.yml
@@ -52,9 +52,7 @@
               resources:
                 limits:
                   cpu: '250m'
-                  memory: >-
-                    {{ "850M" if "test" in openshift_namespace
-                    else "1G" }}
+                  memory: "1G"
               ports:
                 - name: metrics
                   containerPort: 9600

--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -62,6 +62,7 @@ kafka_broker:
 
 zeebe_broker_env:
   PORT: '{{ zeebe_ports.api | string }}'
+  JAVA_OPTS: '-Xmx512m'
   ZEEBE_BROKER_NETWORK_MONITORINGAPI_HOST: '0.0.0.0'
   # https://docs.camunda.io/docs/self-managed/zeebe-deployment/operations/setting-up-a-cluster/
   ZEEBE_LOG_LEVEL: info


### PR DESCRIPTION
- Double default ceiling for total JVM heap space (-Xmx)
- Bump the memory reservation, as this results in the Zeebe pods getting OOMed