### PR TITLE
Feature/data app loaded globally

### DIFF
--- a/apps/fillForm/imports/policy/newTasks.ts
+++ b/apps/fillForm/imports/policy/newTasks.ts
@@ -1,0 +1,103 @@
+import dayjs from "dayjs";
+import {Meteor} from "meteor/meteor";
+import {Tasks} from "/imports/model/tasks";
+import {DoctoralSchool} from "/imports/api/doctoralSchools/schema";
+import {getAssistantAdministrativeMemberships} from "/imports/policy/tasks";
+
+
+export const getTasksQueryForList = (user: Meteor.User | null) => {
+  // at this point, check the user is goodly instanced, or return nothing
+  if (!user) return
+
+  return {
+    ...(!user.isAdmin && filterOutObsoleteTasksQuery()),
+    ...(!user.isAdmin && { "variables.assigneeSciper": user._id }),
+    ...filterOutSubmittedTasksQuery()
+  }
+}
+
+// Define which tasks can be seen from the dashboard
+export const getTasksQueryForDashboard = (
+  user: Meteor.User | null,
+  doctoralSchools : DoctoralSchool[]
+) => {
+  // at this point, check the user is goodly instanced, or return nothing
+  if (!user) return
+
+  return {
+    ...(!user.isAdmin && filterOutObsoleteTasksQuery()),
+    ...filterOutSubmittedTasksQuery(),
+    ...(!user.isAdmin && {
+      '$or': [
+        {"variables.assigneeSciper": user._id},
+        {"variables.phdStudentSciper": user._id},
+        {"variables.programAssistantSciper": user._id},  // Get tasks that we started as programAssistant
+        {"variables.doctoralProgramName": {
+          $in: Object.keys(getAssistantAdministrativeMemberships(user, doctoralSchools))}
+        },  // Get tasks for the group
+      ]
+    }),
+  }
+}
+
+//const gonnaTask = Tasks.find(getTasksQueryForDashboard(user, doctoralSchools), { 'fields': user.isAdmin ? taskFieldsNeededForAdmin : tasksMongoFields })
+
+/**
+ * Used to get the task if the user is allowed to see/edit/proceed
+ */
+export const getUserPermittedTaskDetailed = (user: Meteor.User | null, _id: string) => {
+  // at this point, check the user is goodly instanced, or return nothing
+  if (!user) return
+
+  const taskQuery = {
+    _id: _id,
+    ...(!user.isAdmin && filterOutObsoleteTasksQuery()),
+    ...filterOutSubmittedTasksQuery(),
+    ...(!user.isAdmin && { "variables.assigneeSciper": user._id }),
+  }
+
+  // Set which fields can be seen for a user, depending on their right
+  // Better safe than sorry: by default remove the "not for everyone" ones
+  const fieldsView: Mongo.FieldSpecifier = {
+    // filter out mentor infos
+    'variables.mentorSciper': 0,
+    'variables.mentorName': 0,
+    'variables.mentorEmail': 0,
+
+    // and not really needed stuffs for UI
+    'variables.activityLogs': 0,
+    'journal':0,
+  }
+
+  if (user.isAdmin) {  // admin can see the exclusions, reactivate it
+    delete fieldsView['variables.mentorSciper']
+    delete fieldsView['variables.mentorName']
+    delete fieldsView['variables.mentorEmail']
+    delete fieldsView['journal']
+  }
+
+  return Tasks.find(taskQuery, { 'fields': fieldsView })
+}
+
+/**
+ * Build the filter query on the tasks taht last seen on zeebe is too old
+ * This kind of "desync" can happen, yeah, it has already happened  because some OOM error
+ */
+export const filterOutObsoleteTasksQuery = () => {
+  const today = dayjs()
+  const yesterday = today.subtract(1, 'day')
+
+  return {
+    "journal.lastSeen": { $gte: yesterday.toDate() },
+  }
+}
+
+/**
+ * Filter the already submitted that we keep as rule to not reload,
+ * if a task is coming from Zeebe while being submitted
+ */
+export const filterOutSubmittedTasksQuery = () => {
+  return {
+    'journal.submittedAt': { $exists:false },
+  }
+}

--- a/apps/fillForm/imports/policy/newTasksUnifiedTypes.ts
+++ b/apps/fillForm/imports/policy/newTasksUnifiedTypes.ts
@@ -1,0 +1,64 @@
+import {PhDInputVariables} from "/imports/model/tasksTypes";
+import {Job} from "zeebe-node";
+import {Sciper} from "/imports/api/datatypes";
+import {ParticipantList} from "/imports/model/participants";
+
+
+export const tasksMongoFields = {
+  '_id': 1,
+  'elementId': 1,
+  'processInstanceKey': 1,
+  'workflowInstanceKey': 1,
+  'customHeaders.title': 1,
+  'processDefinitionVersion': 1,
+  'variables.assigneeSciper': 1,
+  'variables.created_at': 1,
+  'variables.created_by': 1,
+  'variables.updated_at': 1,
+  'variables.phdStudentSciper': 1,
+  'variables.phdStudentEmail': 1,
+  'variables.phdStudentName': 1,
+  'variables.phdStudentLastName': 1,
+  'variables.phdStudentFirstName': 1,
+  'variables.thesisDirectorSciper': 1,
+  'variables.thesisDirectorEmail': 1,
+  'variables.thesisDirectorName': 1,
+  'variables.thesisCoDirectorSciper': 1,
+  'variables.thesisCoDirectorEmail': 1,
+  'variables.thesisCoDirectorName': 1,
+  'variables.programDirectorSciper': 1,
+  'variables.programDirectorEmail': 1,
+  'variables.programDirectorName': 1,
+  'variables.doctoralProgramName': 1,
+  'variables.programAssistantSciper': 1,
+  'variables.programAssistantEmail': 1,
+  'variables.programAssistantName': 1,
+}
+
+export const taskFieldsNeededForAdmin = {
+  'variables.mentorSciper': 1,
+  'variables.mentorName': 1,
+  'variables.mentorEmail': 1,
+  'journal.lastSeen': 1,  // to mark it on the list as obosolete
+  ...tasksMongoFields
+}
+
+// define here what is allowed in code, as we filter out a full task to get only useful data
+type UnwantedPhDInputVariablesKeys = "activityLogs"
+
+type PhDInputVariablesDashboard = Omit<PhDInputVariables, UnwantedPhDInputVariablesKeys>
+
+// like the 'Task implements TaskI', minus the unused fields
+export interface ITasks<WorkerInputVariables = PhDInputVariablesDashboard, CustomHeaderShape = {}> extends Job<WorkerInputVariables, CustomHeaderShape> {
+  _id: string
+  elementId: string
+  created_by?: Sciper  // value built from variables.updated_at, see the Task class for details
+  created_at?: Date  // value built from variables.updated_at, see the Task class for details
+  updated_at?: Date  // value built from variables.updated_at, see the Task class for details
+  workflowInstanceKey: string
+  assigneeScipers?: Sciper[]
+  participants: ParticipantList  // values built from participants found in the 'variables' fields, see the Task class for details
+  detail: any
+  isObsolete: boolean | undefined
+  monitorUri?: string
+}

--- a/apps/fillForm/imports/ui/App.tsx
+++ b/apps/fillForm/imports/ui/App.tsx
@@ -3,12 +3,64 @@ import {router} from "/imports/ui/routes";
 import {RouterProvider} from "react-router-dom";
 import {AccountProvider} from "/imports/ui/contexts/Account";
 import {ConnectionStatusProvider} from "/imports/ui/contexts/ConnectionStatus";
+import {DataAppContext} from "/imports/ui/contexts/Tasks";
+import {useTracker} from "meteor/react-meteor-data";
+import {Meteor} from "meteor/meteor";
+import {Tasks} from "/imports/model/tasks";
+import {ITaskList} from "/imports/policy/tasksList/type";
+import {ITaskDashboard} from "/imports/policy/dashboard/type";
+import {DoctoralSchool, DoctoralSchools} from "/imports/api/doctoralSchools/schema";
 
 
-export const App = () => (
+const getDataAppValue = () => {
+  const isTasksListLoading = useTracker(() => {
+    // Note that this subscription will get cleaned up
+    // when your component is unmounted or deps change.
+    const handle = Meteor.subscribe('tasksList');
+    return !handle.ready();
+  }, []);
+
+  const tasksList = useTracker(() => Tasks.find({}).fetch() as ITaskList[])
+
+  const isTasksDashboardLoading = useTracker(() => {
+    // Note that this subscription will get cleaned up
+    // when your component is unmounted or deps change.
+    const handle = Meteor.subscribe('tasksDashboard');
+    return !handle.ready();
+  }, []);
+  const tasksDashboard = useTracker(
+    () => Tasks.find({"elementId": {$ne: "Activity_Program_Assistant_Assigns_Participants"}})
+      .fetch() as ITaskDashboard[])
+
+  const isDoctoralSchoolsLoading = useTracker(() => {
+    // Note that this subscription will get cleaned up
+    // when your component is unmounted or deps change.
+    const handle = Meteor.subscribe('doctoralSchools');
+    return !handle.ready();
+  }, []);
+
+  const doctoralSchools = useTracker(
+    () => DoctoralSchools.find({}, { sort: { 'acronym': 1 } }).fetch() as Array<DoctoralSchool & {readonly:boolean}>
+    , [])
+
+  return {
+    isTasksListLoading,
+    tasksList,
+    isTasksDashboardLoading,
+    tasksDashboard,
+    isDoctoralSchoolsLoading,
+    doctoralSchools,
+  }
+}
+
+export const App = () => {
+  return (
   <ConnectionStatusProvider>
     <AccountProvider>
-      <RouterProvider router={router}/>
+      <DataAppContext.Provider value={ getDataAppValue() } >
+        <RouterProvider router={router}/>
+      </DataAppContext.Provider>
     </AccountProvider>
   </ConnectionStatusProvider>
-)
+  )
+}

--- a/apps/fillForm/imports/ui/components/Dashboard.tsx
+++ b/apps/fillForm/imports/ui/components/Dashboard.tsx
@@ -217,7 +217,7 @@ export function Dashboard() {
             </div>
             {
               Object.keys(groupByWorkflowInstanceTasks).map(
-                (taskGrouper: string) => <DashboardRow workflowInstanceTasks={ groupByWorkflowInstanceTasks[taskGrouper] }/>
+                (taskGrouper: string) => <DashboardRow key={ taskGrouper } workflowInstanceTasks={ groupByWorkflowInstanceTasks[taskGrouper] }/>
              )
             }
           </div>)

--- a/apps/fillForm/imports/ui/components/Dashboard.tsx
+++ b/apps/fillForm/imports/ui/components/Dashboard.tsx
@@ -1,12 +1,11 @@
-import {useTracker} from "meteor/react-meteor-data"
 import {Meteor} from "meteor/meteor"
-import {Tasks} from "/imports/model/tasks";
 import _ from "lodash"
-import React, {CSSProperties} from "react"
+import React, {CSSProperties, useContext} from "react"
 import {Loader} from "@epfl/epfl-sti-react-library";
 import {ParticipantDetail} from "/imports/model/participants";
 import {ITaskDashboard} from "/imports/policy/dashboard/type";
 import {useAccountContext} from "/imports/ui/contexts/Account";
+import {DataAppContext} from "/imports/ui/contexts/Tasks";
 
 
 /*
@@ -163,17 +162,11 @@ const DashboardRow = ({ workflowInstanceTasks } : { workflowInstanceTasks:ITaskD
 
 export function Dashboard() {
   const account = useAccountContext()
+  const appData = useContext(DataAppContext);
 
-  const listLoading = useTracker(() => {
-    // Note that this subscription will get cleaned up
-    // when your component is unmounted or deps change.
-    const handle = Meteor.subscribe('tasksDashboard');
-    return !handle.ready();
-  }, []);
+  const listLoading = appData.isTasksDashboardLoading
 
-  let allTasks = useTracker(
-    () => Tasks.find({"elementId": {$ne: "Activity_Program_Assistant_Assigns_Participants"}})
-      .fetch() as ITaskDashboard[])
+  let allTasks = appData.tasksDashboard
 
   // sort by second part of email address, that's the best way to get the name at this point
   allTasks = _.sortBy(

--- a/apps/fillForm/imports/ui/components/DoctoralSchools/List.tsx
+++ b/apps/fillForm/imports/ui/components/DoctoralSchools/List.tsx
@@ -1,29 +1,21 @@
-import React, {useState} from "react"
-import {useTracker} from "meteor/react-meteor-data";
-import {Meteor} from "meteor/meteor";
+import React, {useContext, useState} from "react"
 import {canEditAtLeastOneDoctoralSchool} from "/imports/policy/doctoralSchools";
 import {Loader} from "@epfl/epfl-sti-react-library";
-import {DoctoralSchool, DoctoralSchools} from "/imports/api/doctoralSchools/schema";
 import {CreateForm} from './Create'
 import {InlineEdit} from './Edit'
 import {useAccountContext} from "/imports/ui/contexts/Account";
+import {DataAppContext} from "/imports/ui/contexts/Tasks";
+import {DoctoralSchool} from "/imports/api/doctoralSchools/schema";
 
 
 export function DoctoralSchoolsList() {
   const account = useAccountContext()
+  const appData = useContext(DataAppContext);
 
   const [showAdd, setShowAdd] = useState(false)
 
-  const doctoralSchoolsLoading = useTracker(() => {
-    // Note that this subscription will get cleaned up
-    // when your component is unmounted or deps change.
-    const handle = Meteor.subscribe('doctoralSchools');
-    return !handle.ready();
-  }, []);
-
-  const doctoralSchools = useTracker(
-    () => DoctoralSchools.find({}, { sort: { 'acronym': 1 } }).fetch() as Array<DoctoralSchool & {readonly:boolean}>
-  , [])
+  const doctoralSchoolsLoading = appData.isDoctoralSchoolsLoading
+  const doctoralSchools = appData.doctoralSchools as Array<DoctoralSchool & {readonly:boolean}>
 
   if (!account || !account.isLoggedIn) return (<Loader message={'Loading your data...'}/>)
 

--- a/apps/fillForm/imports/ui/components/ImportSciper/List.tsx
+++ b/apps/fillForm/imports/ui/components/ImportSciper/List.tsx
@@ -1,17 +1,18 @@
 import {global_Error, Meteor} from "meteor/meteor";
-import React, {useEffect, useState} from "react";
+import React, {useContext, useEffect, useState} from "react";
 import {useTracker} from "meteor/react-meteor-data";
 import {useNavigate, useParams, Link} from "react-router-dom";
 import {Alert, Loader} from "@epfl/epfl-sti-react-library";
 import {ImportScipersList} from "/imports/api/importScipers/schema";
 import StartButton from '/imports/ui/components/ImportSciper/StartButton';
 import {HeaderRow, Row} from "/imports/ui/components/ImportSciper/Row";
-import {DoctoralSchool, DoctoralSchools} from "/imports/api/doctoralSchools/schema";
+import {DoctoralSchool} from "/imports/api/doctoralSchools/schema";
 import {DoctoralSchoolInfo} from "/imports/ui/components/ImportSciper/DoctoralSchoolInfo";
 import toast from "react-hot-toast";
 import _ from "lodash";
 import {useAccountContext} from "/imports/ui/contexts/Account";
 import {canImportScipersFromISA} from "/imports/policy/importScipers";
+import {DataAppContext} from "/imports/ui/contexts/Tasks";
 
 
 export const ImportScipersSchoolSelector = () => {
@@ -153,17 +154,14 @@ export function ImportSciperList({ doctoralSchool }: { doctoralSchool: DoctoralS
 
 export function ImportSciperLoader({doctoralSchoolAcronym}: {doctoralSchoolAcronym?: string}) {
   const account = useAccountContext()
+  const appData = useContext(DataAppContext);
 
-  const doctoralSchoolsLoading = useTracker(() => {
-    // Note that this subscription will get cleaned up
-    // when your component is unmounted or deps change.
-    const handle = Meteor.subscribe('doctoralSchools');
-    return !handle.ready();
-  }, []);
+  const doctoralSchoolsLoading = appData.isDoctoralSchoolsLoading
 
-  const currentDoctoralSchool = useTracker(
-    () => DoctoralSchools.findOne({ acronym: doctoralSchoolAcronym }),
-    [])
+  // const currentDoctoralSchool = useTracker(
+  //   () => DoctoralSchools.findOne({ acronym: doctoralSchoolAcronym }),
+  //   [])
+  const currentDoctoralSchool = appData.doctoralSchools.find(ds => ds.acronym === doctoralSchoolAcronym)
 
   if (!account || !account.isLoggedIn) return (<Loader message={'Loading your data...'}/>)
 

--- a/apps/fillForm/imports/ui/components/TaskList.tsx
+++ b/apps/fillForm/imports/ui/components/TaskList.tsx
@@ -1,8 +1,6 @@
 import {global_Error, Meteor} from "meteor/meteor"
-import React from "react"
+import React, {useContext} from "react"
 import _ from "lodash"
-import {useTracker} from 'meteor/react-meteor-data'
-import {Tasks} from "/imports/model/tasks";
 import {WorkflowStarter} from './workflowStarter'
 import {Button, Loader} from "@epfl/epfl-sti-react-library"
 import {Link} from "react-router-dom"
@@ -14,19 +12,14 @@ import {
 import {toastErrorClosable} from "/imports/ui/components/Toasters";
 import {ITaskList} from "/imports/policy/tasksList/type";
 import {useAccountContext} from "/imports/ui/contexts/Account";
+import {DataAppContext} from "/imports/ui/contexts/Tasks";
 
 export default function TaskList() {
+
   const account = useAccountContext()
+  const appData = useContext(DataAppContext);
 
-  const listLoading = useTracker(() => {
-    // Note that this subscription will get cleaned up
-    // when your component is unmounted or deps change.
-    const handle = Meteor.subscribe('tasksList');
-    return !handle.ready();
-  }, []);
-
-  const tasks = useTracker(() => Tasks.find({}).fetch() as ITaskList[])
-  const groupByTasks = _.groupBy(tasks, 'customHeaders.title')
+  const groupByTasks = _.groupBy(appData.tasksList, 'customHeaders.title')
 
   if (!account || !account.isLoggedIn || !account.user) return (<Loader message={'Loading your data...'}/>)
 
@@ -34,11 +27,15 @@ export default function TaskList() {
     <>
       <WorkflowStarter/>
 
-      {listLoading ? (
-        <Loader message={'Fetching tasks...'}/>
+      { appData.isTasksListLoading ? (
+        <>
+          <Loader message={'Fetching tasks...'}/>
+          <button onClick={ () => appData.setIsTasksListNeeded(true) }>clickme</button>
+        </>
+
       ) : (
         <>
-          {tasks.length > 0 ?
+          {appData.tasksList.length > 0 ?
             Object.keys(groupByTasks).map((taskGrouper: string) => (
               <div key={taskGrouper}>
                 <h3 className={'mt-5'}>{taskGrouper}</h3>

--- a/apps/fillForm/imports/ui/contexts/Tasks.tsx
+++ b/apps/fillForm/imports/ui/contexts/Tasks.tsx
@@ -1,0 +1,26 @@
+import {createContext} from "react";
+import {ITaskList} from "/imports/policy/tasksList/type";
+import {ITaskDashboard} from "/imports/policy/dashboard/type";
+import {DoctoralSchool} from "/imports/api/doctoralSchools/schema";
+
+
+// load all the data needed by the app, so they are loaded globally
+export type DataAppContextType = {
+  isTasksListLoading: boolean;
+  tasksList: ITaskList[];
+  isTasksDashboardLoading: boolean;
+  tasksDashboard: ITaskDashboard[];
+  isDoctoralSchoolsLoading: boolean;
+  doctoralSchools: DoctoralSchool[];
+}
+
+export const DataAppContext = createContext<DataAppContextType>(
+  {
+    isTasksListLoading: true,
+    tasksList: [],
+    isTasksDashboardLoading: true,
+    tasksDashboard: [],
+    isDoctoralSchoolsLoading: true,
+    doctoralSchools: [],
+  }
+)


### PR DESCRIPTION
This is a Work in progress. 
Add a global react provider to manage loading app data. 

- [x] Data loaded globally into the whole app
- [ ] Selected load, so we don't load dashboard tasks if not needed
- or
- [ ] Unify tasksDashboard and tasksList into one Tasks publications