### PR TITLE
[fix] Misc. Prometheus things

### DIFF
--- a/ansible/roles/epfl.esb-vm/tasks/esb-vm-tasks.yml
+++ b/ansible/roles/epfl.esb-vm/tasks/esb-vm-tasks.yml
@@ -66,6 +66,9 @@
   include_tasks:
     file: monitoring.yml
     apply:
-      tags: monitoring
+      tags:
+        - monitoring
+        - monitoring.prometheus
   tags:
     - monitoring
+    - monitoring.prometheus

--- a/ansible/roles/epfl.esb-vm/templates/prometheus-config.yml
+++ b/ansible/roles/epfl.esb-vm/templates/prometheus-config.yml
@@ -20,7 +20,7 @@ scrape_configs:
     static_configs:
       - targets: ['zeebe:9600']
         labels:
-          instance: 'zeebe-broker-0'
+          instance: 'zeebe-0'
           app_instance: prod
           persistence: vm
   - job_name: 'traefik'

--- a/ansible/roles/epfl.phd-assess/tasks/main.yml
+++ b/ansible/roles/epfl.phd-assess/tasks/main.yml
@@ -116,6 +116,7 @@
 - name: Monitoring
   tags:
     - monitoring
+    - monitoring.prometheus
     - monitoring-promote
     - monitoring.zeebe-db-monitor
     - monitoring.zeebe-db-monitor.push

--- a/ansible/roles/epfl.phd-assess/tasks/monitoring.yml
+++ b/ansible/roles/epfl.phd-assess/tasks/monitoring.yml
@@ -78,7 +78,7 @@
               resources:
                 limits:
                   cpu: '100m'
-                  memory: 100M
+                  memory: 200M
           volumes:
             - name: storage
               emptyDir: {}


### PR DESCRIPTION
- Make `-t monitoring.prometheus` work
- Feed more memory to Prometheus, given that it [briefly](https://prometheus.io/docs/prometheus/1.8/storage/#memory-usage) knew how to control its consumption, but [no longer can](https://github.com/helm/charts/issues/19391#issuecomment-676236021) 🤦 