### PR TITLE
[fix] Update metrics URI for Zeebe brokers

### DIFF
--- a/ansible/roles/epfl.esb-vm/templates/prometheus-config.yml
+++ b/ansible/roles/epfl.esb-vm/templates/prometheus-config.yml
@@ -17,6 +17,7 @@ scrape_configs:
 
   # Scrape Docker containers also running on the ESB VM
   - job_name: 'zeebe'
+    metrics_path: /actuator/prometheus
     static_configs:
       - targets: ['zeebe:9600']
         labels:

--- a/ansible/roles/epfl.phd-assess/templates/prometheus-config.yml
+++ b/ansible/roles/epfl.phd-assess/templates/prometheus-config.yml
@@ -56,7 +56,7 @@ global:
 scrape_configs:
   # Prometheus scraping itself.
   # The job name is added as a label `job=<job_name>` to any timeseries scraped from this config.
-  - job_name: 'prometheus'
+  - job_name: '0-prometheus'
 
     # metrics_path defaults to '/metrics'
     # scheme defaults to 'http'.
@@ -65,7 +65,7 @@ scrape_configs:
     - targets: ['localhost:9090']
 
     # Discover Zeebe targets in the same namespace
-  - job_name: "{{ openshift_namespace }}-zeebe-pods"
+  - job_name: "1-{{ openshift_namespace }}-zeebe-pods"
     metrics_path: /actuator/prometheus
     kubernetes_sd_configs:
 {{ _discover_k8s_pods(ns=openshift_namespace, label_selector="for-service==zeebe-gateway") }}
@@ -73,7 +73,7 @@ scrape_configs:
 {{ _common_relabel_configs() }}
 
     # Discover other scrapable targets in the same namespace
-  - job_name: "{{ openshift_namespace }}-other-pods"
+  - job_name: "2-{{ openshift_namespace }}-other-pods"
     # Assume default `metrics_path` (i.e. /metrics)
     kubernetes_sd_configs:
 {{ _discover_k8s_pods(ns=openshift_namespace, label_selector="for-service!=zeebe-gateway") }}

--- a/ansible/roles/epfl.phd-assess/templates/prometheus-config.yml
+++ b/ansible/roles/epfl.phd-assess/templates/prometheus-config.yml
@@ -4,25 +4,17 @@ global:
   evaluation_interval: 15s # Evaluate rules every 15 seconds. The default is every 1 minute.
   # scrape_timeout is set to the global default (10s).
 
-scrape_configs:
-  # Prometheus scraping itself.
-  # The job name is added as a label `job=<job_name>` to any timeseries scraped from this config.
-  - job_name: 'prometheus'
-
-    # metrics_path defaults to '/metrics'
-    # scheme defaults to 'http'.
-
-    static_configs:
-    - targets: ['localhost:9090']
-
-    # Discover scrapable targets in the same namespace
-  - job_name: "{{ openshift_namespace }}-pods"
-    kubernetes_sd_configs:
+{% macro _discover_k8s_pods(ns, label_selector) %}
       - role: pod
         namespaces:
           names:
-            - "{{ openshift_namespace }}"
-    relabel_configs:
+            - "{{ ns }}"
+        selectors:
+        - role: pod
+          label: "{{ label_selector }}"
+{% endmacro %}
+
+{% macro _common_relabel_configs() %}
       # Only keep targets whose port name contains "metrics"
       - action: keep
         source_labels:
@@ -59,3 +51,31 @@ scrape_configs:
         source_labels:
           - instance
         regex: .*2.*
+{% endmacro %}
+
+scrape_configs:
+  # Prometheus scraping itself.
+  # The job name is added as a label `job=<job_name>` to any timeseries scraped from this config.
+  - job_name: 'prometheus'
+
+    # metrics_path defaults to '/metrics'
+    # scheme defaults to 'http'.
+
+    static_configs:
+    - targets: ['localhost:9090']
+
+    # Discover Zeebe targets in the same namespace
+  - job_name: "{{ openshift_namespace }}-zeebe-pods"
+    metrics_path: /actuator/prometheus
+    kubernetes_sd_configs:
+{{ _discover_k8s_pods(ns=openshift_namespace, label_selector="for-service==zeebe-gateway") }}
+    relabel_configs:
+{{ _common_relabel_configs() }}
+
+    # Discover other scrapable targets in the same namespace
+  - job_name: "{{ openshift_namespace }}-other-pods"
+    # Assume default `metrics_path` (i.e. /metrics)
+    kubernetes_sd_configs:
+{{ _discover_k8s_pods(ns=openshift_namespace, label_selector="for-service!=zeebe-gateway") }}
+    relabel_configs:
+{{ _common_relabel_configs() }}


### PR DESCRIPTION
Unlike in [the previous version](https://docs.camunda.io/docs/8.2/self-managed/zeebe-deployment/operations/metrics/#connecting-prometheus), Zeebe 8.3 decided to start serving its metrics [at a new, nonstandard URI](https://docs.camunda.io/docs/self-managed/zeebe-deployment/operations/metrics/#connecting-prometheus). This breaks our monitoring, of course (although there should be an alert that fires when we get no timeseries at all; but this is the topic for another pull request)
